### PR TITLE
Room name is better to be case-insensitive

### DIFF
--- a/app/socket/index.js
+++ b/app/socket/index.js
@@ -34,9 +34,9 @@ module.exports = (socket, io) => {
   console.log(`Client '${socket.id}' connected`);
   let currentRoom = null;
 
-  socket.on('join', (room) => {
-    console.log(`Client '${socket.id}' joined room '${room}'`);
-    currentRoom = room;
+  socket.on('join', (room = '') => {
+    currentRoom = room.toLowerCase();
+    console.log(`Client '${socket.id}' joined room '${currentRoom}'`);
 
     socket.join(currentRoom, () => {
       redis.get(currentRoom).then(result => {


### PR DESCRIPTION
<img alt="case_insensitive_room_name" src="https://user-images.githubusercontent.com/7512625/39957821-c214f752-562b-11e8-8377-b9a23d038e27.jpg" width="200" />

It's hard to say whether this case is a bug or should be a new feature, as it depends on different scenarios.

IMO, the room name is better to be case-insensitive. From the screenshot above, obviously the guys wanted to access same room.

More other cases,

- https://github.com/JUST4FUN will display my profile as well
- https://appear.in/TEST_123456 will display the players in room `test_123456` as well

Open to discussion.